### PR TITLE
Fix multiproxy.js parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ In the resource, add a body mapping template that follows this example for `appl
     "method": "GET|PUT|POST|PATCH|WHATEVER"
   },
   "headers": {
-    "Example-Header": "$util.escapeJavaScript($input.params().header.get("Example-Header")"),
-    "Other-Header": "$util.escapeJavaScript($input.params().header.get("Other-Header")")
+    "Example-Header": "$util.escapeJavaScript($input.params().header.get("Example-Header"))",
+    "Other-Header": "$util.escapeJavaScript($input.params().header.get("Other-Header"))"
   }
 }
 ```


### PR DESCRIPTION
The closing parentheses for the headers were outside the closing quotation marks when they should have been inside.